### PR TITLE
Add BidBotEcho to nick_aliases.txt

### DIFF
--- a/nick_aliases.txt
+++ b/nick_aliases.txt
@@ -1,5 +1,5 @@
 3,ames,ames_c,ames|secondarycore
-3,bidserv
+3,bidserv,bidbotecho
 3,bojii,bojii_
 3,diderobot,diderobot_,diderobot_test
 3,ekimbot,ekimbot-unbound,ekimbot_dev,ekimbot|4,ekimtestbot


### PR DESCRIPTION
Admittedly, this is only relevant for a short time during the year, but
still.  I'm not sure if it should be treated as an alias to bidserv, if
bidserv should be an alias to BidBotEcho, or if BidBotEcho should be its
own entry, but at any rate, it should be treated as a bot, not a user.